### PR TITLE
Fixed an import in code sample for futures

### DIFF
--- a/futures.md
+++ b/futures.md
@@ -30,7 +30,7 @@ with futures.ThreadPoolExecutor(max_workers=4) as e:
 ## Process pool
 
 ```python
-import concurrent.futures
+import concurrent.futures as futures
 import math
 
 PRIMES = [


### PR DESCRIPTION
Otherwise we will get a similar error:
```
  File "pytest2.py", line 23, in <module>
    with futures.ProcessPoolExecutor() as e:
NameError: name 'futures' is not defined
```